### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kgoldrunner.json
+++ b/org.kde.kgoldrunner.json
@@ -12,6 +12,12 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
The installed size reduced from 17.2 MB to 14.7 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.